### PR TITLE
fix: add missing pip packages to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,12 @@
-pytorch
+torch
+torchvision
 matplotlib
 seaborn
 notebook
 pydot
 scikit-learn
+tqdm
+datasets
+tokenizers
+transformers
+evaluate


### PR DESCRIPTION
Hi,

fixes #14 by adding `torchvision`, `datasets`, `tokenizers` and `tqdm`. Also renames `pytorch` to `torch` and add `transformers` and `evaluate`.

