### PR TITLE
Day 2 small fixes

### DIFF
--- a/day2/pytorch_imdb_gpt.py
+++ b/day2/pytorch_imdb_gpt.py
@@ -196,7 +196,7 @@ if __name__ == "__main__":
     trainer = Trainer(
         model=model,
         args=training_args,
-        tokenizer=tokenizer,
+        processing_class=tokenizer,
         data_collator=collator,
         train_dataset=train_dataset_tokenized,
         eval_dataset=validate_dataset_tokenized,

--- a/day2/run-4gpus.sh
+++ b/day2/run-4gpus.sh
@@ -22,4 +22,4 @@ export TOKENIZERS_PARALLELISM=false
 umask 002
 
 set -xv
-torchrun --standalone --nnodes=1 --nproc_per_node=$SLURM_GPUS_PER_NODE $*
+torchrun --standalone --nnodes=1 --nproc_per_node=$SLURM_GPUS_ON_NODE $*


### PR DESCRIPTION
- change deprecated tokenizer in Trainer to processing_class
- SLURM_GPUS_PER_NODE doesn't work in Mahti, change to SLURM_GPUS_ON_NODE